### PR TITLE
Typo fix for Exercise 2 background & instructions

### DIFF
--- a/exercises/ex02/README.md
+++ b/exercises/ex02/README.md
@@ -259,7 +259,7 @@ There is no limit on the number of processes launched by a user on the scientifi
 
 > 3. What software is available via the module environment?
 
-JASPY, jasmin_sci, Intel/GNU compiler, NetCDF library, NAG libray and IDL(Restricted)
+JASPY, jasmin_sci, Intel/GNU compiler, NetCDF library, NAG library and IDL (Restricted)
 
 > 4. How do you switch between different version of a software module?
 


### PR DESCRIPTION
Hi, I am just organising my browser bookmarks and one bookmark I had made some while ago was on the page for 'Exercise 2' noting there was a typo, which I noticed in the past when working through some training exercises for my own JASMIN knowledge. This fixes the typo (and allows me to delete the bookmark to tidy up 🙂 ).