### PR TITLE
Update login servers for March 2026 workshop

### DIFF
--- a/exercises/ex00/README.md
+++ b/exercises/ex00/README.md
@@ -41,6 +41,26 @@ Click the arrow to expand the set of instructions.
    2. Click the link in this email from the JASMIN Accounts Portal to provision your training account.
          - **This is a one-time link** for secure credentials sharing! If you close the tab after entering the event password, **your credentials will be lost**, even if you click on the link in the email again.
 
+   2. Click the link in this email from the JASMIN Accounts Portal to provision your training account.
+   
+   <table>
+      <thead>
+         <tr>
+         <td align="left">
+            ⚠️ Note
+         </td>
+         </tr>
+      </thead>
+
+      <tbody>
+         <tr>
+         <td>
+            <b>This is a one-time link</b> for secure credentials sharing! If you close the tab after entering the event password, <b>your credentials will be lost</b>, even if you click on the link in the email again.
+         </td>
+         </tr>
+      </tbody>
+   </table>
+
    ![Event password page](images/Event-password.png)
 
    _The landing page asking for the event password after clicking the link_

--- a/exercises/ex00/README.md
+++ b/exercises/ex00/README.md
@@ -39,27 +39,23 @@ Click the arrow to expand the set of instructions.
    _The email sent from the JASMIN Accounts Portal_
 
    2. Click the link in this email from the JASMIN Accounts Portal to provision your training account.
-         - **This is a one-time link** for secure credentials sharing! If you close the tab after entering the event password, **your credentials will be lost**, even if you click on the link in the email again.
-
-   2. Click the link in this email from the JASMIN Accounts Portal to provision your training account.
    
-   <table>
-      <thead>
-         <tr>
-         <td align="left">
-            ⚠️ Note
-         </td>
-         </tr>
-      </thead>
-
-      <tbody>
-         <tr>
-         <td>
-            <b>This is a one-time link</b> for secure credentials sharing! If you close the tab after entering the event password, <b>your credentials will be lost</b>, even if you click on the link in the email again.
-         </td>
-         </tr>
-      </tbody>
-   </table>
+<table>
+   <thead>
+      <tr>
+      <td align="left">
+         ⚠️ Note
+      </td>
+      </tr>
+   </thead>
+   <tbody>
+      <tr>
+      <td>
+         <b>This is a one-time link</b> for secure credentials sharing! If you close the tab after entering the event password, <b>your credentials will be lost</b>, even if you click on the link in the email again.
+      </td>
+      </tr>
+   </tbody>
+</table>
 
    ![Event password page](images/Event-password.png)
 

--- a/exercises/ex00/README.md
+++ b/exercises/ex00/README.md
@@ -12,7 +12,7 @@ It helps you set up your computer with the software and training account credent
 > [!NOTE]
 > For the [reasons explained below](#own-vs-training-account), we provide workshop participants with a temporary training account for the duration of the workshop event. Even if you have your own JASMIN account, please use the training account for the workshop event.
 
-Please also see the set of [FAQs](#faq) at the end of this page.
+Please also see [the set of FAQs](#faq) at the end of this page.
 
 ## Instructions
 
@@ -281,13 +281,13 @@ You should see your key fingerprint, i.e. something like this:
 521 SHA256:ZeddNKK5U3am1vyCaUCq4CgMRpvoyv+cJiviqz3zvfw ~/.ssh/id_ecdsa (ECDSA)
 ```
 
-Now try a connection to `login-01.jasmin.ac.uk`, replacing `USERNAME` with the name of your training account:
+Now try a connection to `login.jasmin.ac.uk`, replacing `USERNAME` with the name of your training account:
    
 > [!IMPORTANT]
 > Don't forget the `-A` option for "agent forwarding". This makes your key available to any onward connections you need to make, after connecting to the login node.
 
 ```bash
-ssh -A USERNAME@login-01.jasmin.ac.uk
+ssh -A USERNAME@login.jasmin.ac.uk
 ```
 
 Once you have connected, try `ssh-add -l` again as above, to check that your key is available for an onward connection.

--- a/exercises/ex01/README.md
+++ b/exercises/ex01/README.md
@@ -24,7 +24,7 @@ flowchart TD
 
 At the end of this exercise I will be able to:
 
-- **Connect** to a JASMIN `login` server using a simple terminal client
+- **Connect** to the JASMIN `login` server using a simple terminal client
 - **Locate** my home directory
 - **Make an onward connection** to a `sci` server
 - **Run** a simple command
@@ -32,7 +32,7 @@ At the end of this exercise I will be able to:
 ### JASMIN resources
 
 - JASMIN account with SSH public key uploaded and `jasmin-login` access role
-- `login` server: `login-0[1-4].jasmin.ac.uk`
+- `login` server: `login.jasmin.ac.uk`
 - [JASMIN Help documentation](https://help.jasmin.ac.uk)
 
 ### Local resources
@@ -47,15 +47,15 @@ This is the outline of what you need to do. The recommended way of doing each st
 
 In the text below, you can see the steps needed to do this task, i.e:
 
-1. Connect to a `login` server using a terminal client
+1. Connect to the `login` server using a terminal client
    - (Your key should already be loaded, as per ex00)
-   - Initiate an SSH connection to a `login` server
+   - Initiate an SSH connection to the `login` server
    - Note the list of available `sci` servers
    - Check what directory you are in
    - Check usage of your home directory
    - Check that your SSH key is available to make an onward connection
 1. Make an onward connection to a `sci` server
-   - Login to the `sci` server
+   - Login to a `sci` server
    - Run a simple command
 
 ### Questions to test yourself
@@ -78,9 +78,7 @@ All too easy? Here are some questions to test your knowledge and understanding. 
 > [!NOTE]
 > Please make sure you have read all the information in [exercise 0](../ex00), in particular the recommendation to use a preconfigured training account, and the reasons why. If you are using your **own** account, outside of one of our organised training events, you will need to have completed these steps yourself: [start here](https://help.jasmin.ac.uk/article/185-generate-ssh-key-pair), but be aware not all the steps can be done temporarily for a workshop event.
 
-1. Connect to a `login` server using a terminal client
-
-   * For the workshop, use server `login-01.jasmin.ac.uk` but the full list is in the [help doc](https://help.jasmin.ac.uk/article/191-login-servers).
+1. Connect to the `login` server using a terminal client
 
     * If you have set up your own machine as suggested in [exercise 0: Getting set up for the JASMIN workshop](../ex00), your SSH private key should already be loaded.
 
@@ -98,10 +96,10 @@ All too easy? Here are some questions to test your knowledge and understanding. 
       ```
       In this case, you will need to work out what is wrong before you will be able to connect. Please see the advice in [exercise 0](../ex00) before proceeding.
 
-    * Initiate an SSH connection to a `login` server
+    * Initiate an SSH connection to a `login` server via `login.jasmin.ac.uk`
 
       ```console
-      $ ssh -A train050@login-01.jasmin.ac.uk
+      $ ssh -A train050@login.jasmin.ac.uk
       ```
       <table>
         <thead>

--- a/exercises/ex01/README.md
+++ b/exercises/ex01/README.md
@@ -15,8 +15,8 @@ I want to connect to JASMIN from my own computer to do some work.
 ```mermaid
 flowchart TD
    id1(My computer)
-   -- terminal client -->id2(`login` server)
-   -- terminal client -->id3(`sci` server)
+   -- terminal client -->id2(<code>login</code> server)
+   -- terminal client -->id3(<code>sci</code> server)
    -->id4(do some work)
 ```
 
@@ -212,15 +212,15 @@ Here's how this scenario (right) compares to our original scenario (left):
 ```mermaid
 flowchart TD
    id1(My computer)
-   -- terminal client -->id2(`login` server)
-   -- terminal client -->id3(`sci` server)
+   -- terminal client -->id2(<code>login</code> server)
+   -- terminal client -->id3(<code>sci</code> server)
    -->id4(do some work)
 
    id4-. view terminal output .->id1
 
    id5(My computer)
-   -- special client -->id6(nx server)
-   -- terminal client + X11-forwarding -->id7(`sci` server)
+   -- special client -->id6(<code>nx</code> server)
+   -- terminal client + X11-forwarding -->id7(<code>sci</code> server)
    -->id8(work using graphics)
    
    id8-. view graphics .->id5

--- a/exercises/ex02/README.md
+++ b/exercises/ex02/README.md
@@ -20,7 +20,7 @@ After completing this exercise I will be able to:
 
 ### JASMIN resources
 
-- Scientific analysis servers: `sci-vm-0[1-5].jasmin.ac.uk`
+- Scientific analysis servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3]`
 - Group workspace (GWS): `/gws/pw/j07/workshop`
 - Example Python scripts are provided:
   - `/gws/pw/j07/workshop/exercises/ex02/code/random-number-gen.py`
@@ -37,10 +37,10 @@ After completing this exercise I will be able to:
 
 This is the outline of what you need to do. The recommended way of doing each step is covered in the "Cheat Sheet", but you may wish to try solving it for yourself first.
 
-1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. Your starting point is the JASMIN `login` server (see [exercise 01](../ex01))
 2. Login to a JASMIN scientific analysis server from the `login` server
    - Launch two terminal sessions
-   - Access a JASMIN `login` server on each terminal (see [exercise 01](../ex01))
+   - Access the JASMIN `login` server on each terminal (see [exercise 01](../ex01))
    - Choose a `sci` server with low load
    - Login to the chosen `sci` server in both terminal sessions
 
@@ -113,7 +113,7 @@ You will be able to run and test a script on the scientific analysis servers. Yo
 
 1. Login to a JASMIN scientific analysis server
 
-   - Login to the chosen `sci` server from a JASMIN `login` server
+   - Login to the chosen `sci` server from the JASMIN `login` server
 
    ```bash
    $ ssh -A <username>@sci<number>.jasmin.ac.uk

--- a/exercises/ex04/README.md
+++ b/exercises/ex04/README.md
@@ -20,7 +20,7 @@ After completing this exercise I will be able to:
 ### JASMIN resources
 
 - JASMIN account with SSH public key uploaded and active `jasmin-login` grant
-- `login` server: `login-0[1-4].jasmin.ac.uk`
+- `login` server: `login.jasmin.ac.uk`
 - `sci` servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3]`
 - common software: CDO (Climate Data Operators) tool
 - GWS (read/write): `/gws/pw/j07/workshop`
@@ -35,7 +35,7 @@ After completing this exercise I will be able to:
 
 This is the outline of what you need to do. The recommended way of doing each step is covered in the "Cheat Sheet", but you may wish to try solving it for yourself first.
 
- 1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+ 1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
  1. SSH to a scientific analysis server
  1. Identify the path to the required data file e.g. `https://data.ceda.ac.uk/badc/ecmwf-era-interim/data/monthly-means/gg/as`
  1. Decide on the output file path
@@ -72,7 +72,7 @@ Best practice considerations:
 
 ### Cheat Sheet
 
-1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
 
 2. SSH to a scientific analysis server
 

--- a/exercises/ex05/README.md
+++ b/exercises/ex05/README.md
@@ -19,7 +19,7 @@ After completing this exercise I will be able to:
 ### JASMIN resources
 
 - JASMIN account with SSH public key uploaded and `jasmin-login` privilege
-- login servers: `login-0[1-4].jasmin.ac.uk`
+- `login` server: `login.jasmin.ac.uk`
 - sci servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3]`
 - LOTUS batch processing cluster
 - common software: CDO (Climate Data Operators) tool
@@ -35,7 +35,7 @@ After completing this exercise I will be able to:
 
 This is the outline of what you need to do. The recommended way of doing each step is covered in the "Cheat Sheet" but you may wish to try solving it for yourself first.
 
-1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
 1. SSH to a scientific analysis server
 1. Write an "`extract-era-data.sh`" wrapper script that calls the CDO extraction command
 1. Write a script, called "`submit-all.sh`", to loop over dates from **01**/09/2018 to **02**/09/2018 and submit the "`extract-era-data.sh`" script to LOTUS for each day
@@ -117,7 +117,7 @@ This exercise demonstrates how to:
 
 ### Cheat Sheet
 
-1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
 
 1. SSH to a scientific analysis server ([see above](#jasmin-resources))
 

--- a/exercises/ex07/README.md
+++ b/exercises/ex07/README.md
@@ -20,7 +20,7 @@ After completing this exercise I will be able to:
 ### JASMIN resources
 
 - JASMIN account with SSH public key uploaded and `jasmin-login` privilege
-- login servers: `login-0[1-4].jasmin.ac.uk`
+- `login` server: `login.jasmin.ac.uk`
 - sci servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3]`
 - help documentation at https://help.jasmin.ac.uk
 
@@ -32,7 +32,7 @@ After completing this exercise I will be able to:
 
 This is the outline of what you need to do. The recommended way of doing each step is covered in the "Cheat Sheet" but you may wish to try solving it for yourself first.
 
- 1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+ 1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
  1. SSH to a scientific analysis server
  1. Activate the Jaspy Python 3 environment with the `module` command
  1. Create a Python 3 virtual environment in your `$HOME` directory
@@ -90,7 +90,7 @@ Alternative approaches could include:
 
 ### Cheat Sheet
 
-1. Your starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. Your starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
 
 1. SSH to a scientific analysis server
 

--- a/exercises/ex08/README.md
+++ b/exercises/ex08/README.md
@@ -32,7 +32,7 @@ After completing this exercise you will:
 
 ### JASMIN resources
 
-- Scientific analysis servers: `sci-vm-0[1-6].jasmin.ac.uk`, `sci-ph-0[12].jasmin.ac.uk`
+- Scientific analysis servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3].jasmin.ac.uk`
 - Group workspace: `/gws/pw/j07/workshop`
 - LOTUS batch queues: `workshop` (`short-serial` outside the event)
 - Fortran source code is (available in the Github repository):
@@ -51,7 +51,7 @@ This is the outline of what you need to do. The recommended way of doing each st
 
 1. Login to a physical JASMIN scientific analysis server
    - Launch two terminal sessions
-   - Access a JASMIN login server on each terminal (see exercise 01)
+   - Access a JASMIN `login` server on each terminal (see exercise 01)
    - Choose one of physical sci servers `sci-ph-0[12]` with the lowest load
    - Login to the chosen sci server on each terminal
    - Copy the Fortran source code from the exercise directory (shown in the JASMIN resources section) to your current working directory
@@ -112,7 +112,7 @@ By completing this exercise you will be able to compile and test a serial Fortra
 ### Cheat Sheet
 
 1. Login to a JASMIN scientific analysis server
-   - Login to one of the physical sci `sci-ph-0[12]` machines from a JASMIN login server
+   - Login to one of the physical sci `sci-ph-0[1-3]` machines from a JASMIN `login` server
    ```
    $ ssh -A <username>@sci-ph-01.jasmin.ac.uk
    ```

--- a/exercises/ex11/README.md
+++ b/exercises/ex11/README.md
@@ -32,7 +32,7 @@ After completing this exercise you will:
  
  ### JASMIN resources
 
- * Scientific analysis servers: `sci-vm-0[1-6].jasmin.ac.uk`, `sci-ph-0[1-2].jasmin.ac.uk`
+ * Scientific analysis servers: `sci-vm-0[1-5].jasmin.ac.uk`, `sci-ph-0[1-3].jasmin.ac.uk`
  * Group workspace: `/gws/pw/j07/workshop`
  * LOTUS batch queues: `workshop` (`par-single` or `par-multi` outside the event)
  * Fortran MPI source code is (available in the Github repository): 
@@ -52,7 +52,7 @@ This is the outline of what you need to do. The recommended way of doing each st
 
 1. Login to a JASMIN scientific analysis server 
    * Launch two terminal sessions: terminal 1 will be used for compiling and testing codes on LOTUS while terminal 2 will be used for submitting and monitoring jobs 
-   * Access a JASMIN login server on each terminal (see exercise 01)
+   * Access a JASMIN `login` server on each terminal (see exercise 01)
    * Choose a Sci server with the lowest load 
    * Login to the chosen sci server on each terminal
    * Copy the Fortran source code from the exercise directory (shown in the JASMIN resources section) to your current working directory            

--- a/tutorials/tut02/README.md
+++ b/tutorials/tut02/README.md
@@ -61,7 +61,7 @@ After completing this tutorial I will be able to:
 ### JASMIN resources
 
  * JASMIN account with SSH public key uploaded and `jasmin-login` privilege
- * login servers: `login-0[1-4].jasmin.ac.uk`
+ * `login` server: `login.jasmin.ac.uk`
  * Cylc server: `cylc.jasmin.ac.uk`
  * LOTUS batch processing cluster
  * GWS (read/write): `/gws/pw/j07/workshop`
@@ -77,7 +77,7 @@ After completing this tutorial I will be able to:
 
 This is the outline of the overall task. The recommended way of doing each step is covered in the "Walkthrough" below.
 
- 1. The starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+ 1. The starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
  1. SSH to the Rose & Cylc server (with the `-X` flag to forward X-windows)
  1. In this example you are given the building blocks to construct a "suite file" for use with Rose & Cylc
  1. Wrap the scripts in a Rose suite by copying the example suite to a new directory called `my-suite` and modifying it
@@ -98,7 +98,7 @@ Alternative approaches and good practice might include:
 
 ### Walkthrough
 
-1. The starting point is on a JASMIN `login` server (see [exercise 01](../ex01))
+1. The starting point is on the JASMIN `login` server (see [exercise 01](../ex01))
 
 2. SSH to the Rose & Cylc server (with the `-X` flag to forward X-windows)
    


### PR DESCRIPTION
- Update login server info to reflect single login service
- `login-01`/`login-[01-04]` --> `login`
- Also correct sci machine numbering and other typos
- Make warning about one-time link more prominent
- Fix inline code blocks in mermaid diagrams